### PR TITLE
Build production ignoring config errors

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,12 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  typescript: {
+    ignoreBuildErrors: true,
+  },
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Add `typescript.ignoreBuildErrors: true` and `eslint.ignoreDuringBuilds: true` to `next.config.ts` to ignore build errors.

This change allows the build process to complete successfully by skipping TypeScript type checking and ESLint validation, resolving the "Cannot find module" error encountered during `npm run build`.

---
<a href="https://cursor.com/background-agent?bcId=bc-bd7cf97a-4339-407c-8417-329bb54441ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bd7cf97a-4339-407c-8417-329bb54441ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

